### PR TITLE
タグ名を日時ベースにする

### DIFF
--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -23,10 +23,6 @@ jobs:
         shell: bash
         run: |
           echo "serial=$(TZ=Asia/Tokyo date +%Y%m%d%H%M%S)" >> $GITHUB_OUTPUT
-      - name: シリアルの確認出力
-        run: |
-          echo "シリアル: ${{ steps.serial.outputs.serial }}"
-        shell: bash
   docker:
     runs-on: ubuntu-latest
     needs: serial


### PR DESCRIPTION
Fixes #6

タグがエポック秒だとやはりトラブル時にわかりにくいということで、日本時間ベースでの日時ベースにしています。

それ以外の変更は行っていません。